### PR TITLE
Mark password_authentication as no_log=True to prevent sensitive output

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,9 +1,9 @@
 namespace: avryez
 name: sshd_config_manager
-version: 1.5.0
+version: 1.5.1
 readme: README.md
 authors:
-- Avryez (@Avryez)
+- avryez (@avryez)
 description: >
   A utility module for managing and updating sshd_config entries on remote hosts.
   Ensures specific SSH server settings are present, updated, or removed without

--- a/plugins/modules/update_sshd_config.py
+++ b/plugins/modules/update_sshd_config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright: (c) 2025, Avryez
+# Copyright: (c) 2025, avryez
 # Licensed under the MIT License
 # See LICENSE file in the project root for full license details.
 from __future__ import (absolute_import, division, print_function)
@@ -642,7 +642,8 @@ def run_module():
         password_authentication=dict(
             type='bool',
             required=False,
-            default=None
+            default=None,
+            no_log=True
         ),
         pubkey_authentication=dict(
             type='bool',


### PR DESCRIPTION
This change ensures that password-related values do not appear in Ansible logs, resolving the warning about sensitive data exposure in the module.